### PR TITLE
Created Unit Tests and Fixed Errors

### DIFF
--- a/config_parser.cc
+++ b/config_parser.cc
@@ -199,7 +199,8 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
           new_config);
       config_stack.push(new_config);
     } else if (token_type == TOKEN_TYPE_END_BLOCK) {
-      if (last_token_type != TOKEN_TYPE_STATEMENT_END) {
+      if (last_token_type != TOKEN_TYPE_STATEMENT_END &&
+          last_token_type != TOKEN_TYPE_END_BLOCK) {
         // Error.
         break;
       }

--- a/config_parser.cc
+++ b/config_parser.cc
@@ -197,7 +197,7 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
         break;
       }
     } else if (token_type == TOKEN_TYPE_START_BLOCK) {
-      balanced += 1;
+      balanced++;
       if (last_token_type != TOKEN_TYPE_NORMAL) {
         // Error.
         break;
@@ -207,7 +207,11 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
           new_config);
       config_stack.push(new_config);
     } else if (token_type == TOKEN_TYPE_END_BLOCK) {
-      balanced += -1;
+
+      /* When you have closed a bracket */
+
+      balanced--;
+
       if (last_token_type != TOKEN_TYPE_STATEMENT_END &&
           last_token_type != TOKEN_TYPE_END_BLOCK) {
         // Error.
@@ -223,7 +227,7 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
 
       // Check that brackets are balanced
       if (balanced != 0) {
-        return false;
+        break;
       }
 
       return true;

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -59,3 +59,31 @@ TEST_F(NginxConfigTest, DoubleNestParse) {
     EXPECT_TRUE(ParseString("foo { bar 100; foo2 { bar2 200; } }"));
 
 }
+
+/* Check that having unclosed brackets will fail. */
+TEST_F(NginxConfigTest, UnclosedBrackets) {
+
+    EXPECT_FALSE(ParseString("foo {bar ;"));
+
+}
+
+/* Check that having unbalanced nesting will fail. */
+TEST_F(NginxConfigTest, UnbalancedNest) {
+
+    EXPECT_FALSE(ParseString("foo { bar 100; foo2 { bar2 200; }"));
+
+}
+
+/* Check that having out of order brackets fails. */
+TEST_F(NginxConfigTest, UnorderedBrackets) {
+
+    EXPECT_FALSE(ParseString("foo } bar 100; {"));
+
+}
+
+/* Parsing an empty string fails */
+TEST_F(NginxConfigTest, EmptyConfig) {
+
+    EXPECT_FALSE(ParseString(""));
+
+}

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -1,11 +1,61 @@
 #include "gtest/gtest.h"
 #include "config_parser.h"
 
+class NginxConfigTest : public ::testing::Test {
+protected:
+
+    NginxConfigParser parser_;
+    NginxConfig config_;
+
+    bool ParseString(const std::string& config_string) {
+
+        std::stringstream config_stream(config_string);
+        return parser_.Parse(&config_stream, &config_);
+
+    }
+
+};
+
+/* Tests that it is able to parse a simple config file. */
 TEST(NginxConfigParserTest, SimpleConfig) {
-  NginxConfigParser parser;
-  NginxConfig out_config;
 
-  bool success = parser.Parse("example_config", &out_config);
+    NginxConfigParser parser;
+    NginxConfig out_config;
 
-  EXPECT_TRUE(success);
+    bool success = parser.Parse("example_config", &out_config);
+
+    EXPECT_TRUE(success);
+
+}
+
+/* Checks the output of a parsing of a simple config file. */
+TEST_F(NginxConfigTest, SimpleParse) {
+
+    bool success = ParseString("foo bar;");
+
+    EXPECT_TRUE(success) << "Could not parse simple config";
+
+    EXPECT_EQ(1, config_.statements_.size()) << "Did not get the correct "
+                                                    "number of statements";
+
+    EXPECT_EQ("foo", config_.statements_.at(0)->tokens_.at(0)) <<
+        "Did not get the correct parse value";
+
+    EXPECT_EQ("bar", config_.statements_.at(0)->tokens_.at(1)) <<
+        "Did not get the correct parse value";
+
+}
+
+/* Checks that it can parse a nested config file. */
+TEST_F(NginxConfigTest, NestParse) {
+
+    EXPECT_TRUE(ParseString("foo { bar 100; }"));
+
+}
+
+/* Checks that it can parse a nested config file. */
+TEST_F(NginxConfigTest, DoubleNestParse) {
+
+    EXPECT_TRUE(ParseString("foo { bar 100; foo2 { bar2 200; } }"));
+
 }

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -87,3 +87,13 @@ TEST_F(NginxConfigTest, EmptyConfig) {
     EXPECT_FALSE(ParseString(""));
 
 }
+
+/* Testing whitespace */
+TEST_F(NginxConfigTest, WhiteSpace) {
+
+    EXPECT_TRUE(ParseString(
+        "foo {\n"
+        "bar 100;\n"
+        "}"));
+
+}


### PR DESCRIPTION
Fixed the error where double nested config statements were not able to be parsed. Also fixed the error where unbalanced brackets did not throw an error. 
